### PR TITLE
fix: Fixed setup to include filter + ignore packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ with open("README.md", "r") as fh:
 PACKAGES = [
     "decoratorOperations",
     "decoratorOperations.debounce_functions",
+    "decoratorOperations.filter_functions",
+    "decoratorOperations.ignore_functions",
     "decoratorOperations.throttle_functions",
 ]
 


### PR DESCRIPTION
For some reason, two packages were not included in the project's setup, meaning after installation the project would break at runtime with exception "No module named <package name> [...]"

fixes #2 